### PR TITLE
fix: use importlib.metadata for version instead of hardcoded values

### DIFF
--- a/mcp_server_odoo/__init__.py
+++ b/mcp_server_odoo/__init__.py
@@ -2,6 +2,7 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
+__version__: str
 try:
     __version__ = version("mcp-server-odoo-ei")
 except PackageNotFoundError:

--- a/mcp_server_odoo/__init__.py
+++ b/mcp_server_odoo/__init__.py
@@ -1,6 +1,13 @@
 """MCP Server for Odoo - Model Context Protocol server for Odoo ERP systems."""
 
-__version__ = "0.3.3"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("mcp-server-odoo-ei")
+except PackageNotFoundError:
+    # Package not installed (development mode)
+    __version__ = "0.0.0-dev"
+
 __author__ = "Luciano Bustos"
 __license__ = "MPL-2.0"
 

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional
 
 from mcp.server import FastMCP
 
+from . import __version__
 from .access_control import AccessController
 from .config import OdooConfig, get_config
 from .error_handling import (
@@ -24,8 +25,8 @@ from .tools import register_tools
 # Set up logging
 logger = get_logger(__name__)
 
-# Server version
-SERVER_VERSION = "0.1.0"
+# Server version - imported from package metadata
+SERVER_VERSION = __version__
 
 
 class OdooMCPServer:

--- a/uv.lock
+++ b/uv.lock
@@ -318,7 +318,7 @@ wheels = [
 
 [[package]]
 name = "mcp-server-odoo-ei"
-version = "0.3.3"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
- Read version from pyproject.toml using importlib.metadata (Python standard)
- Remove hardcoded SERVER_VERSION in server.py
- Remove hardcoded __version__ in __init__.py
- Single source of truth: pyproject.toml

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)