### PR TITLE
feat: add update_records tool for batch updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-01-07
+
+### Added
+- **Batch Update Tool**: Added `update_records` tool for updating multiple records in a single API call (#2)
+  - More efficient than calling `update_record` multiple times
+  - Validates all record IDs exist before updating
+  - Atomic operation - if one fails, all fail
+  - Returns count of updated records and their IDs
+
 ## [0.3.2] - 2026-01-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ An MCP server that enables AI assistants like Claude to interact with Odoo ERP s
 - 🔍 **Search and retrieve** any Odoo record (customers, products, invoices, etc.)
 - ✨ **Create new records** with field validation and permission checks
 - ✏️ **Update existing data** with smart field handling
+- ⚡ **Batch update records** - update multiple records in a single API call
 - 🗑️ **Delete records** respecting model-level permissions
 - 📊 **Browse multiple records** and get formatted summaries
 - 🔢 **Count records** matching specific criteria
@@ -530,6 +531,21 @@ Update an existing record.
   }
 }
 ```
+
+### `update_records`
+Update multiple records with the same values in a single API call (batch operation).
+
+```json
+{
+  "model": "project.task",
+  "record_ids": [1, 2, 3, 4, 5],
+  "values": {
+    "display_in_project": true
+  }
+}
+```
+
+This is much more efficient than calling `update_record` multiple times when you need to apply the same changes to many records.
 
 ### `delete_record`
 Delete a record from Odoo.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-server-odoo-ei"
-version = "0.4.1"
+version = "0.4.2"
 description = "A Model Context Protocol server for Odoo ERP systems"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Add new `update_records` tool for batch updating multiple records in a single API call
- Closes #2

## Changes

- **New Tool**: `update_records(model, record_ids, values)` - Updates multiple records with same values
- **Validation**: Verifies all record IDs exist before updating (fails fast with missing IDs)
- **Atomic**: Uses Odoo's native batch `write()` - all succeed or all fail
- **Performance**: Single XML-RPC call instead of N calls for N records

## Test plan

- [x] Unit tests for success case
- [x] Unit tests for validation (empty IDs, empty values, non-existent IDs)
- [x] Unit tests for error handling (access denied, not authenticated, connection error)
- [x] All existing tests pass
- [x] Linters pass (black, ruff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)